### PR TITLE
stupid header_level bug fix

### DIFF
--- a/fandom/FandomPage.py
+++ b/fandom/FandomPage.py
@@ -213,7 +213,7 @@ class FandomPage(object):
           level_tree[-1]['content'] = section_text
           break
         elif isinstance(next_node, Tag):
-          if next_node.name[0] == 'h':
+          if next_node.name.startswith('h') and next_node.name[1:].isdigit(): # don't be stupid: hr =/= h1
             level_tree[-1]['content'] = section_text
             header = next_node.text
             header_level = int(next_node.name[1])


### PR DESCRIPTION
Fixes a bug where hr passes by the if next_node.name[0] == 'h' and fucks up the ENTIRE thing